### PR TITLE
Support root warp upstream version

### DIFF
--- a/CSTI-ModLoader/ModLoader.cs
+++ b/CSTI-ModLoader/ModLoader.cs
@@ -22,7 +22,7 @@ namespace ModLoader
         public string ModEditorVersion;
     }
 
-    [BepInPlugin("Dop.plugin.CSTI.ModLoader", "ModLoader", "2.0.6")]
+    [BepInPlugin("Dop.plugin.CSTI.ModLoader", "ModLoader", "2.1.0")]
     public class ModLoader : BaseUnityPlugin
     {
         public static Version PluginVersion;

--- a/CSTI-ModLoader/Properties/AssemblyInfo.cs
+++ b/CSTI-ModLoader/Properties/AssemblyInfo.cs
@@ -32,4 +32,4 @@ using System.Runtime.InteropServices;
 //通过使用 "*"，如下所示:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0")]
-[assembly: AssemblyFileVersion("2.0.6")]
+[assembly: AssemblyFileVersion("2.1.0")]

--- a/CSTI-ModLoader/WarpperFunction.cs
+++ b/CSTI-ModLoader/WarpperFunction.cs
@@ -355,10 +355,9 @@ namespace ModLoader
                                                 //Required or JsonData thinks it is an Int64 cast.
                                                 setter(obj, (float)((double)fieldWarpData));
                                             }
-                                            else if (field_type == typeof(double))
-                                            {
-                                                setter(obj, (double)fieldWarpData);
-                                            }
+
+                                            //Otherwise it should be a double.  If not, the cast throw will handle it.
+                                            setter(obj, (double)fieldWarpData);
 
                                             break;
 

--- a/CSTI-ModLoader/WarpperFunction.cs
+++ b/CSTI-ModLoader/WarpperFunction.cs
@@ -333,8 +333,48 @@ namespace ModLoader
                             }
                             else
                             {
-                                ModLoader.LogErrorWithModInfo("CommonWarpper MODIFY Wrong WarpData Format " +
-                                                              field_type.Name);
+                                //Assumed to be a compatible direct field.
+                                try
+                                {
+
+                                    switch (fieldWarpData.GetJsonType())
+                                    {
+                                        case JsonType.String:
+                                            setter(obj, (string)fieldWarpData);
+                                            break;
+                                        case JsonType.Int:
+                                            setter(obj, (int)fieldWarpData);
+                                            break;
+                                        case JsonType.Long:
+                                            setter(obj, (long)fieldWarpData);
+                                            break;
+                                        case JsonType.Double:
+
+                                            if (field_type == typeof(float))
+                                            {
+                                                //Required or JsonData thinks it is an Int64 cast.
+                                                setter(obj, (float)((double)fieldWarpData));
+                                            }
+                                            else if (field_type == typeof(double))
+                                            {
+                                                setter(obj, (double)fieldWarpData);
+                                            }
+
+                                            break;
+
+                                        case JsonType.Boolean:
+                                            setter(obj, (bool)fieldWarpData);
+                                            break;
+                                        default:
+                                            throw new ApplicationException($"Unexpected JsonType: {fieldWarpData.GetJsonType()}");
+                                    }
+
+                                }
+                                catch (Exception ex)
+                                {
+                                    ModLoader.LogErrorWithModInfo($"Error setting property data for field: \"{field_name}\" Type: \"{ field_type.Name}\"  {ex}");
+
+                                }
                             }
                         }
                         else


### PR DESCRIPTION
Idea:  Support modifying root objects that are not objects or arrays.

Currently the WarpperFunction.cs::JsonCommonWarpper(Object obj, JsonData json) does not support *WarpType directives that are not an Object or an Array.

This commit is a proposal to allow the *WarpType and *WarpData to point to those items.

For example:
Modifying a stat like this:
{
    "BaseRatePerTickWarpData": -0.5,
    "BaseRatePerTickWarpType": 5
}

Is ignored.

Attached is a simplified example that modifies the Entertainment stat to .5 tick rate from 1.
[WarpRootExample.zip](https://github.com/dop-lm/CSTI-ModLoader/files/11236273/WarpRootExample.zip)
